### PR TITLE
Added meta charset to html file and templates

### DIFF
--- a/templates/paper.js/static/index.html
+++ b/templates/paper.js/static/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="UTF-8">
 <title>
 Paper.js API
 </title>

--- a/templates/paper.js/templates/html.tmpl
+++ b/templates/paper.js/templates/html.tmpl
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="UTF-8">
 <title>{+ data.title +}</title>
 <base target="classFrame">
 <link rel="stylesheet" href="../resources/css/reference.css" type="text/css">

--- a/templates/paper.js/templates/index.tmpl
+++ b/templates/paper.js/templates/index.tmpl
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="UTF-8">
 <title>Paper.js</title>
 <base target="classFrame">
 <link rel="stylesheet" href="../resources/css/reference.css" type="text/css">


### PR DESCRIPTION
These template files are missing a meta charset, causing it to be missing from all paper.js generated docs html files.
