### PR TITLE
Fix inherited deprecated properties and methods are displayed

### DIFF
--- a/templates/paper.js/src/Symbol.js
+++ b/templates/paper.js/src/Symbol.js
@@ -74,7 +74,8 @@ JSDOC.Symbol.prototype.getStaticProperties = function() {
 JSDOC.Symbol.prototype.getInheritedClasses = function() {
 	var inheritedClasses = {};
 	var addInherited = function(symbol) {
-		if (symbol.memberOf != this.alias) {
+		// Skip deprecated properties and methods.
+		if (symbol.memberOf != this.alias && !symbol.isDeprecated) {
 			var _class = inheritedClasses[symbol.memberOf];
 			if (!_class) {
 				_class = inheritedClasses[symbol.memberOf] = {


### PR DESCRIPTION
Made to close an issue reported here: https://github.com/paperjs/paper.js/issues/1461